### PR TITLE
Fix #2 Remove single point of failure

### DIFF
--- a/InvoiceReader.Application/Events/NewInvoiceAddedHandler.cs
+++ b/InvoiceReader.Application/Events/NewInvoiceAddedHandler.cs
@@ -1,9 +1,5 @@
-﻿using System;
-using System.Threading;
+﻿using System.Threading;
 using System.Threading.Tasks;
-using Communication.Sender;
-using InvoiceProcessor.Domain.Enums;
-using InvoiceProcessor.Messages;
 using InvoiceReader.Application.Commands.InvalidateCache;
 using MediatR;
 using InvoiceReader.Messages;
@@ -13,30 +9,13 @@ namespace InvoiceReader.Application.Events
     public class NewInvoiceAddedHandler : AsyncRequestHandler<NewInvoiceAdded>
     {
         private readonly IMediator _mediator;
-        private readonly IDistributedSender _distributedSender;
 
-        public NewInvoiceAddedHandler(IMediator mediator, IDistributedSender distributedSender)
+        public NewInvoiceAddedHandler(IMediator mediator)
         {
             _mediator = mediator;
-            _distributedSender = distributedSender;
         }
 
-        protected override async Task Handle(NewInvoiceAdded request, CancellationToken cancellationToken)
-        {
-            var processStatus =
-                await _distributedSender.GetAsync<GetProcessStatusResult>(
-                    new GetProcessStatusQuery(request.MessageId));
-            
-            if(processStatus.Status == OutBoxStatus.Failed)
-            {
-                return;
-            }
-
-            if (processStatus.Status != OutBoxStatus.Processed)
-            {
-                throw new Exception($"Processing of {request.MessageId} not yet completed");
-            }
-            await _mediator.Send(new InvalidateCache.Command(), cancellationToken);
-        }
+        protected override Task Handle(NewInvoiceAdded request, CancellationToken cancellationToken)
+            => _mediator.Send(new InvalidateCache.Command(), cancellationToken);
     }
 }

--- a/InvoiceReader.Tests/Application/Events/NewInvoiceAddedHandlerTests.cs
+++ b/InvoiceReader.Tests/Application/Events/NewInvoiceAddedHandlerTests.cs
@@ -2,8 +2,6 @@
 using System.Threading;
 using System.Threading.Tasks;
 using Communication.Sender;
-using InvoiceProcessor.Domain.Enums;
-using InvoiceProcessor.Messages;
 using InvoiceReader.Application.Commands.InvalidateCache;
 using InvoiceReader.Application.Events;
 using InvoiceReader.Messages;
@@ -11,7 +9,7 @@ using MediatR;
 using Moq;
 using Xunit;
 
-namespace InvoiceReader.Tests.Application.Commands
+namespace InvoiceReader.Tests.Application.Events
 {
     public class NewInvoiceAddedHandlerTests
     {
@@ -25,48 +23,16 @@ namespace InvoiceReader.Tests.Application.Commands
         }
 
         [Fact]
-        public async Task Invalidate_Cache_When_Request_Processed()
+        public async Task Should_Invalidate_Cache()
         {
             // Arrange
-            _distributedSender
-                .Setup(m => m.GetAsync<GetProcessStatusResult>(It.IsAny<GetProcessStatusQuery>()))
-                .ReturnsAsync(new GetProcessStatusResult(OutBoxStatus.Processed));
-            var handler = new NewInvoiceAddedHandler(_mediator.Object, _distributedSender.Object);
+            var handler = new NewInvoiceAddedHandler(_mediator.Object);
 
             // Act
             await handler.Handle(new NewInvoiceAdded(Guid.NewGuid()));
 
             // Assert
             _mediator.Verify(m => m.Send(It.IsAny<InvalidateCache.Command>(), It.IsAny<CancellationToken>()), Times.Once);
-        }
-
-        [Fact]
-        public async Task Do_Nothing_When_Request_Failed()
-        {
-            // Arrange
-            _distributedSender
-                .Setup(m => m.GetAsync<GetProcessStatusResult>(It.IsAny<GetProcessStatusQuery>()))
-                .ReturnsAsync(new GetProcessStatusResult(OutBoxStatus.Failed));
-            var handler = new NewInvoiceAddedHandler(_mediator.Object, _distributedSender.Object);
-
-            // Act
-            await handler.Handle(new NewInvoiceAdded(Guid.NewGuid()));
-
-            // Assert
-            _mediator.Verify(m => m.Send(It.IsAny<InvalidateCache.Command>(), It.IsAny<CancellationToken>()), Times.Never);
-        }
-
-        [Fact]
-        public async Task Throw_Exception_When_Request_Is_Processing()
-        {
-            // Arrange
-            _distributedSender
-                .Setup(m => m.GetAsync<GetProcessStatusResult>(It.IsAny<GetProcessStatusQuery>()))
-                .ReturnsAsync(new GetProcessStatusResult(OutBoxStatus.Processing));
-            var handler = new NewInvoiceAddedHandler(_mediator.Object, _distributedSender.Object);
-
-            // Act and Assert
-            await Assert.ThrowsAsync<Exception>(async () => await handler.Handle(new NewInvoiceAdded(Guid.NewGuid())));
         }
     }
 }

--- a/readme.md
+++ b/readme.md
@@ -14,7 +14,7 @@ independently.
 
 
 ## Components and their communication
-![Components and their communication](https://user-images.githubusercontent.com/24603959/132550255-f6ea5d6d-7e4e-4eb7-9aea-b8651a3133cc.jpg)
+![Components and their communication](https://user-images.githubusercontent.com/24603959/132898198-71e17f67-1c53-4dd8-90e6-8b632999e4f4.jpg)
 
 #### Client Application
 
@@ -73,7 +73,7 @@ Used as the way of communication among microservie(s) in an asynchronous way.
 ![Process failed request](https://user-images.githubusercontent.com/24603959/132551016-000ed0f2-e205-4193-bacf-ed8c607772b4.jpg)
 
 ### Cache Invalidation
-![Cache Invalidation](https://user-images.githubusercontent.com/24603959/132551018-3878b2d3-b8ef-433c-8987-1f30d8ec9c95.jpg)
+![Cache Invalidation](https://user-images.githubusercontent.com/24603959/132898680-58d3ee2a-7bdf-427c-bf7e-6a5f15d17ec0.jpg)
 
 ### Behind the scenes of retrieving Invoice
 ![Behind the scenes of retrieving Invoice](https://user-images.githubusercontent.com/24603959/132551026-5b5455cb-e44d-4a50-8ee2-d8261d2b3538.jpg)


### PR DESCRIPTION
**What is a Single Point of Failure?**

When one of your microservice (ex. Reader) directly depends on another microservice (ex. Processor). It creates a single point of failure.

In the worst case (heavy load or other difficulties) Processor microservice could be unreachable. In that case, the Reader service would stop working, at least for some of the features. Also, it would be a performance leak for Reader service.

Previously in Invoice.Microservices.ThirdPartyAPIIntegration application, when a new invoice is added, I fire a queue to notify about that action first and do the invoice processing later on. And inside Reader microservice, I did the check to verify the status and do the following operation.

There is a reason behind this ugly operation, we need to call third party services, and our service bus could be unreachable. In that case, we lose the data consistency.

We can do the service bus call and third party service call inside a  transaction. On service bus failure, it would not call the third party service and vice versa for third party service.